### PR TITLE
Resolved the conflict between activeadmin and therole gem by renaming

### DIFF
--- a/app/models/concerns/base_module.rb
+++ b/app/models/concerns/base_module.rb
@@ -1,5 +1,5 @@
 module TheRole
-  module Base
+  module BaseModule
     def has_section? section_name
       hash         =  role_hash
       section_name =  section_name.to_slug_param(sep: '_')

--- a/app/models/concerns/role.rb
+++ b/app/models/concerns/role.rb
@@ -2,7 +2,7 @@ module TheRole
   module Role
     extend ActiveSupport::Concern
 
-    include TheRole::Base
+    include TheRole::BaseModule
 
     def role_hash;
       to_hash;

--- a/app/models/concerns/user.rb
+++ b/app/models/concerns/user.rb
@@ -2,7 +2,7 @@ module TheRole
   module User
     extend ActiveSupport::Concern
 
-    include TheRole::Base
+    include TheRole::BaseModule
 
     included do
       belongs_to :role

--- a/lib/the_role.rb
+++ b/lib/the_role.rb
@@ -35,7 +35,7 @@ _root_ = File.expand_path('../../',  __FILE__)
 require "#{_root_}/config/routes.rb"
 require "#{_root_}/app/controllers/concerns/controller.rb"
 
-%w[ base role user ].each do |concern|
+%w[ base_module role user ].each do |concern|
   require "#{_root_}/app/models/concerns/#{concern}.rb"
 end
 


### PR DESCRIPTION
the base module to basemodule

error:
load_missing_constant': Unable to autoload constant Base