### PR TITLE
gemspec: Drop defunct property rubyforge_project

### DIFF
--- a/the_role.gemspec
+++ b/the_role.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |s|
   s.summary     = %q{Authorization for Rails}
   s.description = %q{Authorization gem for Ruby on Rails with Management Panel}
 
-  s.rubyforge_project = "the_role"
-
   s.files         = `git ls-files`.split("\n").select{ |file_name| !(file_name =~ /^spec/) }
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }


### PR DESCRIPTION
The RubyGems gemspec property `rubyforge_project` has been removed without a replacement. This PR removes that property.

## Background

* [RubyForge was closed down in 2013][1].
* [rubygems/rubygems#2436 deprecated the `rubyforge_project` property][2].

[1]: https://twitter.com/evanphx/status/399552820380053505
[2]: rubygems/rubygems#2436